### PR TITLE
Handling cases where the CAS authentication fails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,8 @@ Metrics/BlockLength:
     - 'lib/capistrano/tasks/oawaiver.rake'
     - 'spec/mailers/waiver_mailer_spec.rb'
     - 'spec/requests/waiver_infos_controller_spec.rb'
+    - 'spec/models/account_spec.rb'
+    - 'spec/rails_helper.rb'
 
 Metrics/ClassLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ end
 
 group :development, :test do
   gem "bixby"
+  gem "database_cleaner-active_record"
   gem "factory_bot_rails"
   gem "pry-byebug"
   gem "rails-controller-testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     debug_inspector (1.1.0)
     devise (4.8.0)
       bcrypt (~> 3.0)
@@ -444,6 +448,7 @@ DEPENDENCIES
   capistrano-rails
   capybara
   coffee-rails (~> 5.0)
+  database_cleaner-active_record
   devise
   execjs
   factory_bot_rails

--- a/app/controllers/accounts/omniauth_callbacks_controller.rb
+++ b/app/controllers/accounts/omniauth_callbacks_controller.rb
@@ -4,6 +4,8 @@ module Accounts
     def cas
       @account = Account.from_omniauth(access_token)
 
+      return cas_failure if @account.nil?
+
       sign_in_and_redirect(@account, event: :authentication)
       set_flash_message(:success, :success, kind: "from Princeton Central Authentication Service") if is_navigational_format?
     end
@@ -12,6 +14,11 @@ module Accounts
 
     def access_token
       request.env["omniauth.auth"]
+    end
+
+    def cas_failure
+      set_flash_message!(:alert, :failure, kind: OmniAuth::Utils.camelize("cas"), reason: "Failed to authenticate using the Princeton University CAS. Please contact support for assistance.")
+      redirect_to(new_account_session_path)
     end
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -8,7 +8,6 @@ class Account < ApplicationRecord
   validates_presence_of :netid
   validates_uniqueness_of :netid
   delegate :to_s, to: :netid
-  delegate :uid, to: :netid
   devise(:omniauthable)
 
   def self.roles(netid)
@@ -19,6 +18,8 @@ class Account < ApplicationRecord
   end
 
   def self.from_omniauth(access_token)
+    return if access_token.nil?
+
     models = where(provider: access_token.provider, netid: access_token.uid)
     models.first_or_create do |account|
       account.netid = access_token.uid
@@ -27,8 +28,8 @@ class Account < ApplicationRecord
     end
   end
 
-  def self.from_cas(access_token)
-    find_by(provider: access_token.provider, netid: access_token.uid)
+  def uid
+    netid
   end
 
   def admin?

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2021_07_27_142554) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "department"
+    t.index ["unique_id"], name: "idx_16506_index_employees_on_unique_id"
     t.index ["unique_id"], name: "index_employees_on_unique_id"
   end
 
@@ -66,7 +67,9 @@ ActiveRecord::Schema.define(version: 2021_07_27_142554) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "notes"
+    t.index ["author_email"], name: "idx_16541_index_waiver_infos_on_author_email"
     t.index ["author_email"], name: "index_waiver_infos_on_author_email"
+    t.index ["requester_email"], name: "idx_16541_index_waiver_infos_on_requester_email"
     t.index ["requester_email"], name: "index_waiver_infos_on_requester_email"
   end
 

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -15,14 +15,6 @@ RSpec.describe AccountsController, type: :controller do
   end
   let(:admin_user) { FactoryBot.create(:admin_user) }
 
-  before do
-    Account.delete_all
-  end
-
-  after do
-    Account.delete_all
-  end
-
   describe "POST /create" do
     context "with valid parameters" do
       it "fails without authentication" do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -7,14 +7,6 @@ RSpec.describe ApplicationController, type: :controller do
   let(:admin_user) { FactoryBot.create(:admin_user) }
   let(:regular_user) { FactoryBot.create(:regular_user) }
 
-  before do
-    Account.delete_all
-  end
-
-  after do
-    Account.delete_all
-  end
-
   describe "#start" do
     it "responds successfully with an HTTP 200 status code" do
       get(:start)

--- a/spec/controllers/waiver_infos_controller_spec.rb
+++ b/spec/controllers/waiver_infos_controller_spec.rb
@@ -10,16 +10,6 @@ RSpec.describe WaiverInfosController, type: :controller do
   let(:admin_user) { FactoryBot.create(:admin_user) }
   let(:requester) { FactoryBot.create(:regular_user, netid: "requester") }
 
-  before do
-    WaiverInfo.delete_all
-    Account.delete_all
-  end
-
-  after do
-    WaiverInfo.delete_all
-    Account.delete_all
-  end
-
   describe "#index_mine" do
     it "redirects for failed authentication attempts" do
       get(:index_mine)

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Account, type: :model do
+describe Account, type: :model do
   it "has a valid factory" do
     expect(FactoryBot.build(:regular_user)).to be_valid
   end
@@ -18,5 +18,33 @@ RSpec.describe Account, type: :model do
     user = FactoryBot.build(:regular_user)
     user.save
     expect(described_class.new(netid: user.netid).save).to eq(false)
+  end
+
+  describe ".from_omniauth" do
+    let(:access_token) do
+      double
+    end
+
+    before do
+      allow(access_token).to receive(:uid).and_return("jrg5")
+      allow(access_token).to receive(:provider).and_return("cas")
+    end
+
+    it "constructs and persists a new Account Model from a CAS access token" do
+      account = described_class.from_omniauth(access_token)
+
+      expect(account).to be_a(described_class)
+      expect(account.role).to eq("LOGGEDIN")
+      expect(account.provider).to eq("cas")
+      expect(account.uid).to eq("jrg5")
+    end
+
+    context "when an invalid access token is used" do
+      it "returns a nil value" do
+        account = described_class.from_omniauth(nil)
+
+        expect(account).to be nil
+      end
+    end
   end
 end

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -3,14 +3,6 @@
 require "rails_helper"
 
 describe AccountsController, type: :request do
-  before do
-    Account.delete_all
-  end
-
-  after do
-    Account.delete_all
-  end
-
   describe "POST /accounts" do
     let(:valid_attributes) do
       {

--- a/spec/requests/application_spec.rb
+++ b/spec/requests/application_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ApplicationController, type: :request do
+  describe "GET /sign_in" do
+    it "authenticates using the access token" do
+      get("/sign_in")
+
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to(new_account_session_path)
+    end
+  end
+
+  describe "GET /login" do
+    it "authenticates using the access token" do
+      get("/login")
+
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to(new_account_session_path)
+    end
+  end
+end

--- a/spec/requests/waiver_infos_controller_spec.rb
+++ b/spec/requests/waiver_infos_controller_spec.rb
@@ -5,16 +5,6 @@ require "rails_helper"
 describe "Waivers", type: :request do
   let(:admin_user) { FactoryBot.create(:admin_user) }
 
-  before(:all) do
-    MailRecord.delete_all
-    WaiverInfo.delete_all
-  end
-
-  after(:all) do
-    MailRecord.delete_all
-    WaiverInfo.delete_all
-  end
-
   describe "/waiver/requester/me" do
     let(:user) { FactoryBot.create(:regular_user) }
     let(:waiver_info) { FactoryBot.create(:waiver_info, requester: admin_user.netid, requester_email: admin_user.email) }


### PR DESCRIPTION
Resolves #51 by addressing the following:

- Handling cases where the CAS authentication fails
- Adding the database_cleaner-active_record Gem for supporting model persistence within test suites