### PR TITLE
Updating sunspot_rails and sunspot_solr to clone directly from the latest release on GitHub

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem "activerecord-pedantmysql2-adapter"
 gem "bundler", "~> 2.1"
@@ -42,8 +43,9 @@ gem "roo", "~> 1.13.2"
 # bundle exec rake doc:rails generates the API under doc/api.
 gem "sdoc", "~> 1.1", group: :doc
 gem "sprockets", "~> 3.0"
-gem "sunspot_rails"
-gem "sunspot_solr"
+
+gem "sunspot_rails", github: "sunspot/sunspot", glob: "sunspot_rails/*.gemspec", ref: "6cddd9f"
+gem "sunspot_solr", github: "sunspot/sunspot", glob: "sunspot_solr/*.gemspec", ref: "6cddd9f"
 
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem "turbolinks"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,21 @@
+GIT
+  remote: https://github.com/sunspot/sunspot.git
+  revision: 6cddd9f53e3eb311ee1875435b91071ceae292ce
+  ref: 6cddd9f
+  glob: sunspot_rails/*.gemspec
+  specs:
+    sunspot_rails (2.5.0)
+      rails (>= 3)
+      sunspot (= 2.5.0)
+
+GIT
+  remote: https://github.com/sunspot/sunspot.git
+  revision: 6cddd9f53e3eb311ee1875435b91071ceae292ce
+  ref: 6cddd9f
+  glob: sunspot_solr/*.gemspec
+  specs:
+    sunspot_solr (2.5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -406,10 +424,6 @@ GEM
     sunspot (2.5.0)
       pr_geohash (~> 1.0)
       rsolr (>= 1.1.1, < 3)
-    sunspot_rails (2.5.0)
-      rails (>= 3)
-      sunspot (= 2.5.0)
-    sunspot_solr (2.5.0)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
@@ -490,8 +504,8 @@ DEPENDENCIES
   sdoc (~> 1.1)
   sprockets (~> 3.0)
   sqlite3
-  sunspot_rails
-  sunspot_solr
+  sunspot_rails!
+  sunspot_solr!
   therubyracer
   turbolinks
   uglifier (>= 1.3.0)

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -92,8 +92,6 @@ class Employee < ApplicationRecord
           Sunspot.index(records.select(&:indexable?))
           Sunspot.commit if options[:batch_commit]
         end
-
-        options[:progress_bar] = options[:progress_bar].increment(records.length) if options[:progress_bar]
       end
     else
       Sunspot.index! includes(options[:include]).select(&:indexable?)


### PR DESCRIPTION
Updating sunspot_rails and sunspot_solr to clone directly from the latest release on GitHub latest release on GitHub (this was necessary in order to ensure that breaking changes in ActiveRecord 6.y releases no longer trigger errors when indexing)