### PR TITLE
Adding oawaiver-staging1 as a staging server for Capistrano deployments

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -8,4 +8,5 @@ set :rails_env, "staging"
 # server list. The second argument is a, or duck-types, Hash and is
 # used to set extended properties on the server.
 
+server "oawaiver-staging1.princeton.edu", user: "deploy", roles: %w[app db web]
 server "oawaiver-staging2.princeton.edu", user: "deploy", roles: %w[app db web]


### PR DESCRIPTION
Adding oawaiver-staging1 as a staging server for Capistrano deployments (this was blocked by https://github.com/pulibrary/oawaiver/commit/58f72ad7747e28d9437d4de994d1c0082cf7f8f5)