### PR TITLE
Disabling TLS for SMTP integration for the staging and production environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,9 +133,6 @@ jobs:
           at: << pipeline.parameters.working-directory >>
       - setup-bundler
       - setup-node
-      # This is required for `rails db:schema:load`
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y postgresql-client || true
       - run:
           name: Wait for DB
           command: dockerize -wait tcp://localhost:5432 -timeout 1m

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 ruby 3.2.3
-nodejs 18.20.4
+nodejs 18.20.6
 yarn 1.22.10

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -130,7 +130,8 @@ Rails.application.configure do
 
   config.action_mailer.smtp_settings = {
     address: action_mailer_host,
-    port: action_mailer_port.to_i
+    port: action_mailer_port.to_i,
+    enable_starttls: false
   }
   config.action_mailer.default_options = {
     from: 'no-reply@princeton.edu'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -79,7 +79,11 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = { address: '127.0.0.1', port: 1025 }
+  config.action_mailer.smtp_settings = {
+    address: '127.0.0.1',
+    port: 1025,
+    enable_starttls: false
+  }
   config.action_mailer.default_options = {
     from: 'no-reply@princeton.edu'
   }


### PR DESCRIPTION
Resolves #232 by addressing the following:

- Disabling TLS for SMTP integration for the staging and production environment
- Upgrading the Node.js dependency to 18.20.6